### PR TITLE
Fix calculation of Global Moran's I

### DIFF
--- a/src/moran.cpp
+++ b/src/moran.cpp
@@ -75,7 +75,7 @@ List globalmoran(NumericVector x, NumericMatrix mat) {
     }
     Ii(i) = z(i)*temp/m2;
   }
-  double moran = sum(Ii);
+  double moran = sum(Ii)/normc;
   
   List ret;
   ret["moran"] = moran;


### PR DESCRIPTION
The normalizing constant is not included in the calculation of `global_morans()`, although it is calculated.  This PR properly divides the numerator by the calculated normalizing constant.